### PR TITLE
Wire rbloom runtime smoke test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,9 @@ test:
     - rbloom
   commands:
     - pip check
+    - python run_test.py
+  files:
+    - run_test.py
   requires:
     - pip
 


### PR DESCRIPTION
This is a test-only follow-up to wire the existing recipe-local `run_test.py` into package tests. The previous platform/test follow-up added the Bloom filter smoke script, but the recipe did not execute it.\n\nValidation:\n- `python -m py_compile recipe/run_test.py`\n- `pixi exec -s python=3.12 -s rbloom=1.5.4 python recipe/run_test.py`\n- `conda-smithy recipe-lint --conda-forge recipe`\n- `git diff --check`\n\nNo build number bump: this only changes package test coverage.